### PR TITLE
fix: encode package name for tidelift url

### DIFF
--- a/src/components/Estimate.tsx
+++ b/src/components/Estimate.tsx
@@ -15,7 +15,9 @@ export function Estimate({ estimatedPackage }: EstimateProps) {
 		lifted,
 		name,
 	} = estimatedPackage;
-	const href = `https://tidelift.com/lifter/search/npm/${encodeURIComponent(name)}`;
+	const href = `https://tidelift.com/lifter/search/npm/${encodeURIComponent(
+		name
+	)}`;
 
 	return (
 		<tr className={styles.estimate}>

--- a/src/components/Estimate.tsx
+++ b/src/components/Estimate.tsx
@@ -15,7 +15,7 @@ export function Estimate({ estimatedPackage }: EstimateProps) {
 		lifted,
 		name,
 	} = estimatedPackage;
-	const href = `https://tidelift.com/lifter/search/npm/${name}`;
+	const href = `https://tidelift.com/lifter/search/npm/${encodeURIComponent(name)}`;
 
 	return (
 		<tr className={styles.estimate}>


### PR DESCRIPTION
## PR Checklist

I'm sorry, but I am skipping the whole process because it is a quick fix.

- [ ] Addresses an existing open issue
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The following link doesn't work:

https://tidelift.com/lifter/search/npm/@ts-morph/common

But this one does:

https://tidelift.com/lifter/search/npm/%40ts-morph%2Fcommon

So, this change just url encodes.
