### PR TITLE
fix: correct ownership search params retrieval

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,8 @@
-import { EstimatedPackage, tideliftMeUp } from "tidelift-me-up";
-import { PackageOwnership } from "tidelift-me-up";
+import {
+	EstimatedPackage,
+	PackageOwnership,
+	tideliftMeUp,
+} from "tidelift-me-up";
 
 import { Footer } from "~/components/Footer";
 import { MainArea } from "~/components/MainArea";
@@ -14,7 +17,11 @@ export interface HomeProps {
 
 export default async function Home({ searchParams }: HomeProps) {
 	const options = {
-		ownership: searchParams["ownership"] as PackageOwnership[],
+		ownership: [
+			searchParams["author"] === "on" && "author",
+			searchParams["maintainer"] === "on" && "maintainer",
+			searchParams["publisher"] === "on" && "publisher",
+		].filter(Boolean) as PackageOwnership[],
 		since: (searchParams["since"] || undefined) as string | undefined,
 		username: searchParams["username"] as string,
 	};


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #22
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Previously (as described in #22), the `Home` component thought it could take in ownership options from an `ownership` array in the search params. But it was wrong! They come in as individual params that might be set to `"on"`.

This changes the `options.ownership` value to be an array:

1. It starts off with three elements.
    * Each is an `&&` check for whether a particular `searchParams` property is `"on"`. 
    * Their results are each either `false` or that particular property (e.g. `"author"`)
2. `.filter(Boolean)` removes each of those `false` values (e.g. instead of `["author", false]` it'll now be `["author"]`)
3. `as PackageOwnership[]` tells TypeScript that it's specifically an array of the `PackageOwnership` elements
    * That `PackageOwnership` type is `"author" | "maintainer" | "publisher"`: so, not just any old string, but specifically one of those three possible string values