### PR TITLE
feat: add Scroll to Top button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,17 +29,15 @@ export default async function Home({ searchParams }: HomeProps) {
 
 	return (
 		<>
+			<ScrollButton />
 			<MainArea as="main" className={styles.main}>
-				<h1 className={styles.h1} id="title">
-					tidelift-me-up
-				</h1>
+				<h1 className={styles.h1}>tidelift-me-up</h1>
 				<p className={styles.p}>
 					Find your npm packages eligible for Tidelift funding 💸
 				</p>
 				<OptionsForm options={options} />
 				<ResultDisplay result={result} />
 			</MainArea>
-			<ScrollButton />
 			<Footer />
 		</>
 	);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,8 +36,8 @@ export default async function Home({ searchParams }: HomeProps) {
 				</p>
 				<OptionsForm options={options} />
 				<ResultDisplay result={result} />
-				<ScrollButton />
 			</MainArea>
+			<ScrollButton />
 			<Footer />
 		</>
 	);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Footer } from "~/components/Footer";
 import { MainArea } from "~/components/MainArea";
 import { OptionsForm } from "~/components/OptionsForm";
 import { ResultDisplay } from "~/components/ResultDisplay";
+import { ScrollButton } from "~/components/ScrollButton";
 
 import styles from "./page.module.css";
 
@@ -35,6 +36,7 @@ export default async function Home({ searchParams }: HomeProps) {
 				</p>
 				<OptionsForm options={options} />
 				<ResultDisplay result={result} />
+				<ScrollButton />
 			</MainArea>
 			<Footer />
 		</>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,9 @@ export default async function Home({ searchParams }: HomeProps) {
 	return (
 		<>
 			<MainArea as="main" className={styles.main}>
-				<h1 className={styles.h1}>tidelift-me-up</h1>
+				<h1 className={styles.h1} id="title">
+					tidelift-me-up
+				</h1>
 				<p className={styles.p}>
 					Find your npm packages eligible for Tidelift funding 💸
 				</p>

--- a/src/components/ScrollButton.module.css
+++ b/src/components/ScrollButton.module.css
@@ -1,14 +1,13 @@
 .scrollButton {
 	position: fixed;
-	bottom: 5;
-	right: 5;
+	bottom: 40px;
+	right: 40px;
 	background: var(--colors-background-bold);
 	border-radius: 4px;
 	border-radius: var(--border-radius-large);
 	border: none;
 	color: var(--color-background);
 	cursor: pointer;
-	/* display: flex; */
 	font-weight: bold;
 	justify-content: center;
 	padding: 0.5rem 0.75rem;

--- a/src/components/ScrollButton.module.css
+++ b/src/components/ScrollButton.module.css
@@ -1,0 +1,18 @@
+.scrollButton {
+	position: fixed;
+	bottom: 5;
+	right: 5;
+	background: var(--colors-background-bold);
+	border-radius: 4px;
+	border-radius: var(--border-radius-large);
+	border: none;
+	color: var(--color-background);
+	cursor: pointer;
+	/* display: flex; */
+	font-weight: bold;
+	justify-content: center;
+	padding: 0.5rem 0.75rem;
+	text-align: center;
+	text-decoration: none;
+	text-shadow: 0 0 5px var(--color-shadow);
+}

--- a/src/components/ScrollButton.module.css
+++ b/src/components/ScrollButton.module.css
@@ -21,7 +21,7 @@
 	.scrollButton {
 		position: fixed;
 		bottom: 40px;
-		right: 45%;
-		left: 45%;
+		right: 40%;
+		left: 40%;
 	}
 }

--- a/src/components/ScrollButton.module.css
+++ b/src/components/ScrollButton.module.css
@@ -1,5 +1,6 @@
 .scrollButton {
 	position: fixed;
+	display: flex;
 	bottom: 40px;
 	right: 40px;
 	background: var(--colors-background-bold);
@@ -14,4 +15,13 @@
 	text-align: center;
 	text-decoration: none;
 	text-shadow: 0 0 5px var(--color-shadow);
+}
+
+@media screen and (width <= 870px) {
+	.scrollButton {
+		position: fixed;
+		bottom: 40px;
+		right: 45%;
+		left: 45%;
+	}
 }

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -1,32 +1,20 @@
 "use client";
 
-import { useState } from "react";
-
 export function ScrollButton() {
-	const [visible, setVisible] = useState(false);
-
-	const toggleVisible = () => {
-		const scrolled = document.documentElement.scrollTop;
-		if (scrolled > 100) {
-			setVisible(true);
-		} else if (scrolled <= 100) {
-			setVisible(false);
-		}
-	};
-
 	const scrollToTop = () => {
+		console.log("wheeeee", window);
 		window.scrollTo({
 			behavior: "smooth",
+			left: 0,
 			top: 0,
 		});
 	};
 
-	window.addEventListener("scroll", toggleVisible);
-
 	return (
 		<button
 			onClick={scrollToTop}
-			style={{ display: visible ? "inline" : "none" }}
+			type="button"
+			// style={{ display: visible ? "inline" : "none" }}
 		>
 			⬆️
 		</button>

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -11,10 +11,8 @@ export function ScrollButton() {
 		const scrolled = document.body.scrollTop;
 		if (scrolled > 100) {
 			setVisible(true);
-			console.log("we be scrolling", scrolled);
 		} else if (scrolled <= 100) {
 			setVisible(false);
-			console.log("no scroll", scrolled);
 		}
 	};
 

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -6,7 +6,7 @@ export function ScrollButton() {
 	const [visible, setVisible] = useState(false);
 
 	const toggleVisible = () => {
-		const scrolled = document.documentElement.scrollTop;
+		const scrolled = document.body.scrollTop;
 		if (scrolled > 100) {
 			setVisible(true);
 			console.log("we be scrolling", scrolled);

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -9,11 +9,13 @@ export function ScrollButton() {
 
 	const toggleVisible = () => {
 		const scrolled = document.body.scrollTop;
-		if (scrolled > 100) {
-			setVisible(true);
-		} else if (scrolled <= 100) {
-			setVisible(false);
-		}
+		setVisible(scrolled > 100);
+		// scrolled > 100 ? setVisible(true) : setVisible(false)
+		// if (scrolled > 100) {
+		// 	setVisible(true);
+		// } else if (scrolled <= 100) {
+		// 	setVisible(false);
+		// }
 	};
 
 	const scrollToTop = () => {
@@ -23,13 +25,14 @@ export function ScrollButton() {
 		});
 	};
 
-	document.body.addEventListener("scroll", toggleVisible);
+	// document.body.addEventListener("scroll", toggleVisible);
+	document.body.addEventListener("scroll", toggleVisible, { passive: true });
 
 	return (
 		<button
 			className={styles.scrollButton}
 			onClick={scrollToTop}
-			style={{ display: visible ? "inline" : "none" }}
+			style={{ display: visible ? "flex" : "none" }}
 			type="button"
 		>
 			Back to Top⬆

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 export function ScrollButton() {
-	const scrollToTop = () => {
+	const scrollToTop = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+		e.preventDefault();
 		console.log("wheeeee", window);
+		const href = e.currentTarget.href;
+		const targetID = href.replace(/.*#/, "");
+		const elem = document.getElementById(targetID);
 		window.scrollTo({
 			behavior: "smooth",
-			left: 0,
+
 			top: 0,
 		});
 	};

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -16,7 +16,7 @@ export function ScrollButton() {
 			type="button"
 			// style={{ display: visible ? "inline" : "none" }}
 		>
-			⬆️
+			Back to Top⬆
 		</button>
 	);
 }

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -1,6 +1,21 @@
 "use client";
 
+import { useState } from "react";
+
 export function ScrollButton() {
+	const [visible, setVisible] = useState(false);
+
+	const toggleVisible = () => {
+		const scrolled = document.documentElement.scrollTop;
+		if (scrolled > 100) {
+			setVisible(true);
+			console.log("we be scrolling", scrolled);
+		} else if (scrolled <= 100) {
+			setVisible(false);
+			console.log("no scroll", scrolled);
+		}
+	};
+
 	const scrollToTop = () => {
 		document.body.scrollTo({
 			behavior: "smooth",
@@ -8,8 +23,14 @@ export function ScrollButton() {
 		});
 	};
 
+	document.body.addEventListener("scroll", toggleVisible);
+
 	return (
-		<button onClick={scrollToTop} type="button">
+		<button
+			onClick={scrollToTop}
+			style={{ display: visible ? "inline" : "none" }}
+			type="button"
+		>
 			Back to Top⬆
 		</button>
 	);

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -1,26 +1,28 @@
 "use client";
 
-export function ScrollButton() {
-	const scrollToTop = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-		e.preventDefault();
-		console.log("wheeeee", window);
-		const href = e.currentTarget.href;
-		const targetID = href.replace(/.*#/, "");
-		const elem = document.getElementById(targetID);
-		window.scrollTo({
-			behavior: "smooth",
+import Link from "next/link";
 
-			top: 0,
-		});
-	};
+export function ScrollButton() {
+	// const scrollToTop = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+	// 	e.preventDefault();
+	// 	const href = e.currentTarget.href;
+	// 	const targetID = href.replace(/.*#/, "");
+	// 	const elem = document.getElementById(targetID);
+	// 	window.scrollTo({
+	// 		top: elem?.getBoundingClientRect().top,
+	// 		// eslint-disable-next-line perfectionist/sort-objects
+	// 		behavior: "smooth",
+	// 	});
+	// };
 
 	return (
-		<button
-			onClick={scrollToTop}
+		<Link
+			href="#title"
+			// onClick={scrollToTop}
 			type="button"
 			// style={{ display: visible ? "inline" : "none" }}
 		>
 			Back to Top⬆
-		</button>
+		</Link>
 	);
 }

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -10,12 +10,6 @@ export function ScrollButton() {
 	const toggleVisible = () => {
 		const scrolled = document.body.scrollTop;
 		setVisible(scrolled > 100);
-		// scrolled > 100 ? setVisible(true) : setVisible(false)
-		// if (scrolled > 100) {
-		// 	setVisible(true);
-		// } else if (scrolled <= 100) {
-		// 	setVisible(false);
-		// }
 	};
 
 	const scrollToTop = () => {
@@ -25,7 +19,6 @@ export function ScrollButton() {
 		});
 	};
 
-	// document.body.addEventListener("scroll", toggleVisible);
 	document.body.addEventListener("scroll", toggleVisible, { passive: true });
 
 	return (

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -3,22 +3,25 @@
 import Link from "next/link";
 
 export function ScrollButton() {
-	// const scrollToTop = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-	// 	e.preventDefault();
-	// 	const href = e.currentTarget.href;
-	// 	const targetID = href.replace(/.*#/, "");
-	// 	const elem = document.getElementById(targetID);
-	// 	window.scrollTo({
-	// 		top: elem?.getBoundingClientRect().top,
-	// 		// eslint-disable-next-line perfectionist/sort-objects
-	// 		behavior: "smooth",
-	// 	});
-	// };
+	const scrollToTop = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+		e.preventDefault();
+		const href = e.currentTarget.href;
+		console.log("href:", href);
+		const targetID = href.replace(/.*#/, "");
+		console.log("targetID:", targetID);
+		const elem = document.getElementById(targetID);
+		console.log("elem:", elem);
+		window.scrollTo({
+			top: elem?.getBoundingClientRect().top,
+			// eslint-disable-next-line perfectionist/sort-objects
+			behavior: "smooth",
+		});
+	};
 
 	return (
 		<Link
 			href="#title"
-			// onClick={scrollToTop}
+			onClick={scrollToTop}
 			type="button"
 			// style={{ display: visible ? "inline" : "none" }}
 		>

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+import styles from "./ScrollButton.module.css";
+
 export function ScrollButton() {
 	const [visible, setVisible] = useState(false);
 
@@ -27,6 +29,7 @@ export function ScrollButton() {
 
 	return (
 		<button
+			className={styles.scrollButton}
 			onClick={scrollToTop}
 			style={{ display: visible ? "inline" : "none" }}
 			type="button"

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -1,31 +1,16 @@
 "use client";
 
-import Link from "next/link";
-
 export function ScrollButton() {
-	const scrollToTop = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-		e.preventDefault();
-		const href = e.currentTarget.href;
-		console.log("href:", href);
-		const targetID = href.replace(/.*#/, "");
-		console.log("targetID:", targetID);
-		const elem = document.getElementById(targetID);
-		console.log("elem:", elem);
-		window.scrollTo({
-			top: elem?.getBoundingClientRect().top,
-			// eslint-disable-next-line perfectionist/sort-objects
+	const scrollToTop = () => {
+		document.body.scrollTo({
 			behavior: "smooth",
+			top: 0,
 		});
 	};
 
 	return (
-		<Link
-			href="#title"
-			onClick={scrollToTop}
-			type="button"
-			// style={{ display: visible ? "inline" : "none" }}
-		>
+		<button onClick={scrollToTop} type="button">
 			Back to Top⬆
-		</Link>
+		</button>
 	);
 }

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+export function ScrollButton() {
+	const [visible, setVisible] = useState(false);
+
+	const toggleVisible = () => {
+		const scrolled = document.documentElement.scrollTop;
+		if (scrolled > 100) {
+			setVisible(true);
+		} else if (scrolled <= 100) {
+			setVisible(false);
+		}
+	};
+
+	const scrollToTop = () => {
+		window.scrollTo({
+			behavior: "smooth",
+			top: 0,
+		});
+	};
+
+	window.addEventListener("scroll", toggleVisible);
+
+	return (
+		<button
+			onClick={scrollToTop}
+			style={{ display: visible ? "inline" : "none" }}
+		>
+			⬆️
+		</button>
+	);
+}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to tidelift-me-up-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #007
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Previously if a search returned multiple pages of results the user needed to manually scroll to return to the search form. 

These changes add a scroll to top button component to improve UI. 

How `ScrollButton` works:
- `setState` hook for `[visible, setVisible]` is set to `false`
- `document.body.addEventListener("scroll", toggleVisible, { passive: true })` listens for the scroll event and sets the passive option to true to improve performance.
- `toggleVisible` function references `document.body` using the built in `scrollTop` property and updates state to `visible` after scrolling >100 pixels, rendering the button in the DOM
- The `scrollToTop` function uses the built in browser method `scrollTo` to scroll to the `top: 0` coordinate of `document.body`. 
- `scrollToTop` is called  when the button is clicked by the user with a `onClick` event handler
- 