### PR TITLE
feat: hide estimates for lifted packages

### DIFF
--- a/src/components/Estimate.tsx
+++ b/src/components/Estimate.tsx
@@ -6,15 +6,17 @@ import styles from "./Estimate.module.css";
 
 export interface EstimateProps {
 	estimatedPackage: EstimatedPackage;
+	showEstimates: boolean;
 }
 
-export function Estimate({ estimatedPackage }: EstimateProps) {
+export function Estimate({ estimatedPackage, showEstimates }: EstimateProps) {
 	const {
 		data: { description },
 		estimatedMoney,
 		lifted,
 		name,
 	} = estimatedPackage;
+
 	const href = `https://tidelift.com/lifter/search/npm/${encodeURIComponent(
 		name,
 	)}`;
@@ -31,9 +33,11 @@ export function Estimate({ estimatedPackage }: EstimateProps) {
 				</Anchor>
 				<em className={styles.description}>{description}</em>
 			</td>
-			<td className={styles.moneyCell}>
-				<div>~${Math.round(estimatedMoney)}</div>
-			</td>
+			{showEstimates ? (
+				<td className={styles.moneyCell}>
+					{lifted ? null : <div>~${Math.round(estimatedMoney)}</div>}
+				</td>
+			) : null}
 			<td className={styles.liftedCell}>
 				{lifted ? (
 					<Anchor href={href} target="_blank">

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -53,12 +53,17 @@ export function ResultDisplay({ result }: ResultDisplayProps) {
 
 	return (
 		<ResultsContainer
-			heading={`${counted(result.length, "Liftable Package")} Found`}
+			heading={`${counted(
+				result.length,
+				`${showEstimates ? "Liftable" : "Lifted"} Package`,
+			)} Found`}
 		>
-			<p className={styles.p}>
-				With an unclaimed funding estimate of{" "}
-				<b>~${sumEstimateFunding(result)}</b>
-			</p>
+			{showEstimates && (
+				<p className={styles.p}>
+					With an unclaimed funding estimate of{" "}
+					<b>~${sumEstimateFunding(result)}</b>
+				</p>
+			)}
 			<table className={styles.estimates}>
 				<TableHead
 					order={order}

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -47,17 +47,23 @@ export function ResultDisplay({ result }: ResultDisplayProps) {
 		}
 	}
 
+	const showEstimates = result.some(
+		(packageEstimate) => !packageEstimate.lifted,
+	);
+
 	return (
 		<ResultsContainer
 			heading={`${counted(result.length, "Liftable Package")} Found`}
 		>
 			<p className={styles.p}>
-				With a funding estimate of <b>~${sumEstimateFunding(result)}</b>
+				With an unclaimed funding estimate of{" "}
+				<b>~${sumEstimateFunding(result)}</b>
 			</p>
 			<table className={styles.estimates}>
 				<TableHead
 					order={order}
 					setSortAndOrder={setSortAndOrder}
+					showEstimates={showEstimates}
 					sort={sort}
 				/>
 				<tbody>
@@ -92,6 +98,7 @@ export function ResultDisplay({ result }: ResultDisplayProps) {
 							<Estimate
 								estimatedPackage={packageEstimate}
 								key={packageEstimate.name}
+								showEstimates={showEstimates}
 							/>
 						))}
 				</tbody>
@@ -106,6 +113,7 @@ function counted(count: number, text: string) {
 
 function sumEstimateFunding(packages: EstimatedPackage[]) {
 	const total = packages
+		.filter((estimate) => !estimate.lifted)
 		.reduce((total, current) => total + current.estimatedMoney, 0)
 		.toLocaleString("en-US", {
 			maximumFractionDigits: 0,

--- a/src/components/TableHead.tsx
+++ b/src/components/TableHead.tsx
@@ -10,9 +10,15 @@ export interface TableHeadProps {
 	order: TableOrder;
 	setSortAndOrder: (received: TableSort) => void;
 	sort: TableSort;
+	showEstimates: boolean;
 }
 
-export function TableHead({ order, setSortAndOrder, sort }: TableHeadProps) {
+export function TableHead({
+	order,
+	setSortAndOrder,
+	showEstimates,
+	sort,
+}: TableHeadProps) {
 	return (
 		<thead>
 			<tr>
@@ -37,29 +43,31 @@ export function TableHead({ order, setSortAndOrder, sort }: TableHeadProps) {
 						)}
 					</button>
 				</th>
-				<th className={styles.th}>
-					<div className={styles.centerAlignContainer}>
-						<button
-							className={clsx(
-								styles.sortWidget,
-								sort === "estimate" && styles.isActive,
-							)}
-							onClick={() => setSortAndOrder("estimate")}
-						>
-							Estimate
-							{sort === "estimate" && (
-								<span
-									className={clsx(
-										styles.caret,
-										order === "descending" && styles.isDescending,
-									)}
-								>
-									▾
-								</span>
-							)}
-						</button>
-					</div>
-				</th>
+				{showEstimates ? (
+					<th className={styles.th}>
+						<div className={styles.centerAlignContainer}>
+							<button
+								className={clsx(
+									styles.sortWidget,
+									sort === "estimate" && styles.isActive,
+								)}
+								onClick={() => setSortAndOrder("estimate")}
+							>
+								Estimate
+								{sort === "estimate" && (
+									<span
+										className={clsx(
+											styles.caret,
+											order === "descending" && styles.isDescending,
+										)}
+									>
+										▾
+									</span>
+								)}
+							</button>
+						</div>
+					</th>
+				) : null}
 
 				<th className={styles.th}>
 					<div className={styles.centerAlignContainer}>

--- a/src/components/TableHead.tsx
+++ b/src/components/TableHead.tsx
@@ -9,8 +9,8 @@ type TableSort = "estimate" | "lifted" | "name" | undefined;
 export interface TableHeadProps {
 	order: TableOrder;
 	setSortAndOrder: (received: TableSort) => void;
-	sort: TableSort;
 	showEstimates: boolean;
+	sort: TableSort;
 }
 
 export function TableHead({


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #262
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Hides lifted package estimates in two ways:

* If all packages are lifted, hides the _Estimate_ column altogether
* Otherwise, hides the estimate for any package that's lifted