### PR TITLE
feat: make filter options collapsible

### DIFF
--- a/src/components/OptionsForm.module.css
+++ b/src/components/OptionsForm.module.css
@@ -106,6 +106,7 @@
 .secondaryOptions {
 	flex-direction: column;
 	gap: 3rem;
+	margin-top: 1.25rem;
 }
 
 @media screen and (width >= 700px) {
@@ -139,15 +140,16 @@
 	padding: 0.5rem;
 }
 
-.toggleButton {
-	display: flex;
-	justify-content: center;
+.optionsSummary {
 	align-items: center;
-	background: none;
-	border: none;
-	padding: 0;
-	margin: 0;
-	font: inherit;
-	color: inherit;
 	cursor: pointer;
+	display: flex;
+	font-style: italic;
+	gap: 4px;
+	justify-content: center;
+	list-style: none;
+}
+
+.optionsDetails[open] .chevronIcon {
+	transform: rotate(180deg);
 }

--- a/src/components/OptionsForm.module.css
+++ b/src/components/OptionsForm.module.css
@@ -138,3 +138,16 @@
 	height: 2rem;
 	padding: 0.5rem;
 }
+
+.toggleButton {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+}

--- a/src/components/OptionsForm.tsx
+++ b/src/components/OptionsForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { PackageOwnership } from "tidelift-me-up";
 
 import { CallToAction } from "./CallToAction";
@@ -19,13 +18,7 @@ export interface OptionsFormProps {
 export function OptionsForm({ options }: OptionsFormProps) {
 	const ownerships = new Set(options.ownership);
 
-	const [isSecondaryOptionsVisible, setIsSecondaryOptionsVisible] = useState(
-		!options.username,
-	);
-
-	const toggleSecondaryOptions = () => {
-		setIsSecondaryOptionsVisible(!isSecondaryOptionsVisible);
-	};
+	const optionsExpanded = !options.username;
 
 	return (
 		<form className={styles.optionsForm}>
@@ -50,33 +43,24 @@ export function OptionsForm({ options }: OptionsFormProps) {
 			</div>
 
 			<div className={styles.secondaryOptionsArea}>
-				<button
-					className={styles.toggleButton}
-					onClick={toggleSecondaryOptions}
-					type="button"
-				>
-					optionally, filter by
-					<svg
-						fill="none"
-						height="24"
-						stroke="currentColor"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						strokeWidth="2"
-						style={{
-							transform: isSecondaryOptionsVisible
-								? "rotate(180deg)"
-								: "rotate(0deg)",
-						}}
-						viewBox="0 0 24 24"
-						width="24"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<path d="M6 9l6 6 6-6" />
-					</svg>
-				</button>
-
-				{isSecondaryOptionsVisible && (
+				<details className={styles.optionsDetails} open={optionsExpanded}>
+					<summary className={styles.optionsSummary}>
+						optionally, filter by{" "}
+						<svg
+							className={styles.chevronIcon}
+							fill="none"
+							height="24"
+							stroke="currentColor"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							strokeWidth="2"
+							viewBox="0 0 24 24"
+							width="24"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path d="M6 9l6 6 6-6" />
+						</svg>
+					</summary>
 					<div className={styles.secondaryOptions}>
 						<div className={styles.secondaryOptionArea}>
 							<label className={styles.labelSecondary} htmlFor="since">
@@ -114,7 +98,7 @@ export function OptionsForm({ options }: OptionsFormProps) {
 							</div>
 						</fieldset>
 					</div>
-				)}
+				</details>
 			</div>
 		</form>
 	);

--- a/src/components/OptionsForm.tsx
+++ b/src/components/OptionsForm.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { PackageOwnership } from "tidelift-me-up";
 
 import { CallToAction } from "./CallToAction";
@@ -15,6 +18,14 @@ export interface OptionsFormProps {
 
 export function OptionsForm({ options }: OptionsFormProps) {
 	const ownerships = new Set(options.ownership);
+
+	const [isSecondaryOptionsVisible, setIsSecondaryOptionsVisible] = useState(
+		!options.username,
+	);
+
+	const toggleSecondaryOptions = () => {
+		setIsSecondaryOptionsVisible(!isSecondaryOptionsVisible);
+	};
 
 	return (
 		<form className={styles.optionsForm}>
@@ -39,44 +50,71 @@ export function OptionsForm({ options }: OptionsFormProps) {
 			</div>
 
 			<div className={styles.secondaryOptionsArea}>
-				<h2 className={styles.h2}>optionally, filter by:</h2>
-				<div className={styles.secondaryOptions}>
-					<div className={styles.secondaryOptionArea}>
-						<label className={styles.labelSecondary} htmlFor="since">
-							Updated Since
-						</label>
-						<input
-							className={styles.inputSecondary}
-							defaultValue={options.since && options.since.toString()}
-							id="since"
-							name="since"
-							type="date"
-						></input>
-					</div>
+				<button
+					className={styles.toggleButton}
+					onClick={toggleSecondaryOptions}
+					type="button"
+				>
+					optionally, filter by
+					<svg
+						fill="none"
+						height="24"
+						stroke="currentColor"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth="2"
+						style={{
+							transform: isSecondaryOptionsVisible
+								? "rotate(180deg)"
+								: "rotate(0deg)",
+						}}
+						viewBox="0 0 24 24"
+						width="24"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path d="M6 9l6 6 6-6" />
+					</svg>
+				</button>
 
-					<fieldset className={styles.secondaryOptionArea} name="ownership">
-						<legend className={styles.legendSecondary}>
-							Relationship to Project
-						</legend>
-						<div className={styles.fieldsetOptions}>
-							{(["author", "maintainer", "publisher"] as const).map(
-								(ownershipForm) => (
-									<div className={styles.secondaryOption} key={ownershipForm}>
-										<input
-											defaultChecked={ownerships.has(ownershipForm)}
-											id={ownershipForm}
-											name={ownershipForm}
-											type="checkbox"
-										/>
-										<label htmlFor={ownershipForm}>
-											{upperFirst(ownershipForm)}
-										</label>
-									</div>
-								),
-							)}
+				{isSecondaryOptionsVisible && (
+					<div className={styles.secondaryOptions}>
+						<div className={styles.secondaryOptionArea}>
+							<label className={styles.labelSecondary} htmlFor="since">
+								Updated Since
+							</label>
+							<input
+								className={styles.inputSecondary}
+								defaultValue={options.since && options.since.toString()}
+								id="since"
+								name="since"
+								type="date"
+							></input>
 						</div>
-					</fieldset>
-				</div>
+
+						<fieldset className={styles.secondaryOptionArea} name="ownership">
+							<legend className={styles.legendSecondary}>
+								Relationship to Project
+							</legend>
+							<div className={styles.fieldsetOptions}>
+								{(["author", "maintainer", "publisher"] as const).map(
+									(ownershipForm) => (
+										<div className={styles.secondaryOption} key={ownershipForm}>
+											<input
+												defaultChecked={ownerships.has(ownershipForm)}
+												id={ownershipForm}
+												name={ownershipForm}
+												type="checkbox"
+											/>
+											<label htmlFor={ownershipForm}>
+												{upperFirst(ownershipForm)}
+											</label>
+										</div>
+									),
+								)}
+							</div>
+						</fieldset>
+					</div>
+				)}
 			</div>
 		</form>
 	);


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to tidelift-me-up-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/tidelift-me-up-site/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Previously, the filter options were always visible and could not be collapsed.

Now, the filter options can be collapsed, and the behavior is as follows:
- By default, the filter options are visible when the site loads:
<img width="411" alt="filter-options-visible" src="https://github.com/user-attachments/assets/a545f2e9-990a-4720-8e87-00c90d9e69e8">

- Users can toggle the filter options open and closed by clicking on the "Filter options by v" button:
<img width="391" alt="filter-options-hidden" src="https://github.com/user-attachments/assets/67f7f7b0-f247-4e08-ab7b-350331402ea3">

- The filter options automatically close when a search is submitted:
<img width="385" alt="search-results" src="https://github.com/user-attachments/assets/dfc2060c-5f10-4870-85e2-46141378b263">

Lastly, another fav emoji of mine: 🌱!